### PR TITLE
Added Support to Track History through Wikiwand. 

### DIFF
--- a/chrome/content.js
+++ b/chrome/content.js
@@ -1,15 +1,18 @@
-function isValidWikipediaArticle() {
-    // Check if the URL follows the typical pattern for Wikipedia articles
-    // This regex matches the main article pages but excludes special pages, user pages, etc.
-    const urlRegex = /^https?:\/\/[a-z]+\.wikipedia\.org\/wiki\/(?!Special:|User:|Wikipedia:|File:|MediaWiki:|Template:|Help:|Category:|Portal:|Draft:|TimedText:|Module:|Gadget:|Gadget_definition:|Education_Program:|Topic:|Book:|Special:Search|Special:RecentChanges).+/;
-    return urlRegex.test(window.location.href);
+function isValidArticleUrl() {
+    const wikipediaRegex = /^https?:\/\/[a-z]+\.wikipedia\.org\/wiki\/(?!Special:|User:|Wikipedia:|File:|MediaWiki:|Template:|Help:|Category:|Portal:|Draft:|TimedText:|Module:|Gadget:|Gadget_definition:|Education_Program:|Topic:|Book:|Special:Search|Special:RecentChanges).+/;
+    const wikiwandRegex = /^https?:\/\/www\.wikiwand\.com\/en\/.+/;
+
+    const url = window.location.href;
+    return wikipediaRegex.test(url) || wikiwandRegex.test(url);
 }
 
 function sendArticleInfo() {
-    if (isValidWikipediaArticle()) {
+    if (isValidArticleUrl()) {
         const title = document.querySelector('h1').innerText;
         const url = window.location.href;
-        const parent = document.referrer.includes("wikipedia.org") && isValidWikipediaArticle(document.referrer) ? document.referrer : null;
+        // Check for referrer from both wikipedia and wikiwand, normalize if needed
+        const validReferrer = (url) => isValidArticleUrl(url) ? url : null;
+        const parent = document.referrer ? validReferrer(document.referrer) : null;
 
         chrome.runtime.sendMessage({
             article: { title, url, parent }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -7,7 +7,8 @@
         "storage"
     ],
     "host_permissions": [
-        "*://*.wikipedia.org/*"
+        "*://*.wikipedia.org/*",
+        "*://*.wikiwand.com/*"
     ],
     "background": {
         "service_worker": "background.js"
@@ -15,6 +16,7 @@
     "content_scripts": [
         {
             "matches": ["*://*.wikipedia.org/*"],
+            "matches": ["*://*.wikiwand.com/*"],
             "js": ["content.js"]
         }
     ],

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -1,15 +1,18 @@
-function isValidWikipediaArticle() {
-    // Check if the URL follows the typical pattern for Wikipedia articles
-    // This regex matches the main article pages but excludes special pages, user pages, etc.
-    const urlRegex = /^https?:\/\/[a-z]+\.wikipedia\.org\/wiki\/(?!Special:|User:|Wikipedia:|File:|MediaWiki:|Template:|Help:|Category:|Portal:|Draft:|TimedText:|Module:|Gadget:|Gadget_definition:|Education_Program:|Topic:|Book:|Special:Search|Special:RecentChanges).+/;
-    return urlRegex.test(window.location.href);
+function isValidArticleUrl() {
+    const wikipediaRegex = /^https?:\/\/[a-z]+\.wikipedia\.org\/wiki\/(?!Special:|User:|Wikipedia:|File:|MediaWiki:|Template:|Help:|Category:|Portal:|Draft:|TimedText:|Module:|Gadget:|Gadget_definition:|Education_Program:|Topic:|Book:|Special:Search|Special:RecentChanges).+/;
+    const wikiwandRegex = /^https?:\/\/www\.wikiwand\.com\/en\/.+/;
+
+    const url = window.location.href;
+    return wikipediaRegex.test(url) || wikiwandRegex.test(url);
 }
 
 function sendArticleInfo() {
-    if (isValidWikipediaArticle()) {
+    if (isValidArticleUrl()) {
         const title = document.querySelector('h1').innerText;
         const url = window.location.href;
-        const parent = document.referrer.includes("wikipedia.org") && isValidWikipediaArticle(document.referrer) ? document.referrer : null;
+        // Check for referrer from both wikipedia and wikiwand, normalize if needed
+        const validReferrer = (url) => isValidArticleUrl(url) ? url : null;
+        const parent = document.referrer ? validReferrer(document.referrer) : null;
 
         browser.runtime.sendMessage({
             article: { title, url, parent }

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -6,7 +6,8 @@
     "permissions": [
     "tabs",
     "storage",
-    "*://*.wikipedia.org/*"
+    "*://*.wikipedia.org/*",
+    "*://*.wikiwand.org/*"
     ],
     "background": {
     "scripts": ["background.js"]

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -14,6 +14,7 @@
     "content_scripts": [
     {
         "matches": ["*://*.wikipedia.org/*"],
+        "matches": ["*://*.wikiwand.com/*"],
         "js": ["content.js"]
     }
     ],


### PR DESCRIPTION
I usually use [Wikiwand](https://www.wikiwand.com) as my primary client for reading Wikipedia, I have updated the extension to work with both the official mirror and the wikiwand version. Have tested on chrome; not too sure about my firefox code however. Thanks for the project!