### PR TITLE
Add regular expression about Chinese wikipage with different characters.

### DIFF
--- a/chrome/content.js
+++ b/chrome/content.js
@@ -1,7 +1,7 @@
 function isValidWikipediaArticle() {
     // Check if the URL follows the typical pattern for Wikipedia articles
     // This regex matches the main article pages but excludes special pages, user pages, etc.
-    const urlRegex = /^https?:\/\/[a-z]+\.wikipedia\.org\/wiki\/(?!Special:|User:|Wikipedia:|File:|MediaWiki:|Template:|Help:|Category:|Portal:|Draft:|TimedText:|Module:|Gadget:|Gadget_definition:|Education_Program:|Topic:|Book:|Special:Search|Special:RecentChanges).+/;
+    const urlRegex = /^https?:\/\/[a-z]+\.wikipedia\.org\/(?:wiki|zh-cn|zh-hk|zh-mo|zh-my|zh-sg|zh-tw)\/(?!Special:|User:|Wikipedia:|File:|MediaWiki:|Template:|Help:|Category:|Portal:|Draft:|TimedText:|Module:|Gadget:|Gadget_definition:|Education_Program:|Topic:|Book:|Special:Search|Special:RecentChanges).+/;
     return urlRegex.test(window.location.href);
 }
 

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -1,7 +1,7 @@
 function isValidWikipediaArticle() {
     // Check if the URL follows the typical pattern for Wikipedia articles
     // This regex matches the main article pages but excludes special pages, user pages, etc.
-    const urlRegex = /^https?:\/\/[a-z]+\.wikipedia\.org\/wiki\/(?!Special:|User:|Wikipedia:|File:|MediaWiki:|Template:|Help:|Category:|Portal:|Draft:|TimedText:|Module:|Gadget:|Gadget_definition:|Education_Program:|Topic:|Book:|Special:Search|Special:RecentChanges).+/;
+    const urlRegex = /^https?:\/\/[a-z]+\.wikipedia\.org\/(?:wiki|zh-cn|zh-hk|zh-mo|zh-my|zh-sg|zh-tw)\/(?!Special:|User:|Wikipedia:|File:|MediaWiki:|Template:|Help:|Category:|Portal:|Draft:|TimedText:|Module:|Gadget:|Gadget_definition:|Education_Program:|Topic:|Book:|Special:Search|Special:RecentChanges).+/;
     return urlRegex.test(window.location.href);
 }
 


### PR DESCRIPTION
Chinese wiki-page have different character choice, for different character, the domain name will become something like:
https://zh.wikipedia.org/zh-cn/xxx
instead of 
https://zh.wikipedia.org/wiki/xxx
So I modify the regular expression in content, and this can recognize these cases. 
![图片](https://github.com/demegire/wiki-journey/assets/71842413/5f9aef0c-f96a-47f7-a373-da0f8ade7c51)
