### PR TITLE
Change the title fetch for the Chinese wiki pages.

### DIFF
--- a/chrome/content.js
+++ b/chrome/content.js
@@ -7,7 +7,7 @@ function isValidWikipediaArticle() {
 
 function sendArticleInfo() {
     if (isValidWikipediaArticle()) {
-        const title = document.querySelector('h1').innerText;
+        const title = document.querySelector('h1 > :first-child').innerText;
         const url = window.location.href;
         const parent = document.referrer.includes("wikipedia.org") && isValidWikipediaArticle(document.referrer) ? document.referrer : null;
 

--- a/chrome/content.js
+++ b/chrome/content.js
@@ -1,7 +1,7 @@
 function isValidWikipediaArticle() {
     // Check if the URL follows the typical pattern for Wikipedia articles
     // This regex matches the main article pages but excludes special pages, user pages, etc.
-    const urlRegex = /^https?:\/\/[a-z]+\.wikipedia\.org\/(?:wiki|zh-cn|zh-hk|zh-mo|zh-my|zh-sg|zh-tw)\/(?!Special:|User:|Wikipedia:|File:|MediaWiki:|Template:|Help:|Category:|Portal:|Draft:|TimedText:|Module:|Gadget:|Gadget_definition:|Education_Program:|Topic:|Book:|Special:Search|Special:RecentChanges).+/;
+    const urlRegex = /^https?:\/\/[a-z-]+\.wikipedia\.org\/(?:wiki|zh-cn|zh-hk|zh-mo|zh-my|zh-sg|zh-tw)\/(?!Special:|User:|Wikipedia:|File:|MediaWiki:|Template:|Help:|Category:|Portal:|Draft:|TimedText:|Module:|Gadget:|Gadget_definition:|Education_Program:|Topic:|Book:|Special:Search|Special:RecentChanges).+/;
     return urlRegex.test(window.location.href);
 }
 

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -7,7 +7,7 @@ function isValidWikipediaArticle() {
 
 function sendArticleInfo() {
     if (isValidWikipediaArticle()) {
-        const title = document.querySelector('h1').innerText;
+        const title = document.querySelector('h1 > :first-child').innerText;
         const url = window.location.href;
         const parent = document.referrer.includes("wikipedia.org") && isValidWikipediaArticle(document.referrer) ? document.referrer : null;
 

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -1,7 +1,7 @@
 function isValidWikipediaArticle() {
     // Check if the URL follows the typical pattern for Wikipedia articles
     // This regex matches the main article pages but excludes special pages, user pages, etc.
-    const urlRegex = /^https?:\/\/[a-z]+\.wikipedia\.org\/(?:wiki|zh-cn|zh-hk|zh-mo|zh-my|zh-sg|zh-tw)\/(?!Special:|User:|Wikipedia:|File:|MediaWiki:|Template:|Help:|Category:|Portal:|Draft:|TimedText:|Module:|Gadget:|Gadget_definition:|Education_Program:|Topic:|Book:|Special:Search|Special:RecentChanges).+/;
+    const urlRegex = /^https?:\/\/[a-z-]+\.wikipedia\.org\/(?:wiki|zh-cn|zh-hk|zh-mo|zh-my|zh-sg|zh-tw)\/(?!Special:|User:|Wikipedia:|File:|MediaWiki:|Template:|Help:|Category:|Portal:|Draft:|TimedText:|Module:|Gadget:|Gadget_definition:|Education_Program:|Topic:|Book:|Special:Search|Special:RecentChanges).+/;
     return urlRegex.test(window.location.href);
 }
 


### PR DESCRIPTION
In Chinese wiki pages, text "[edit]" will enter the title name, for example

![圖片](https://github.com/demegire/wiki-journey/assets/71842413/4196f80a-c5f2-4793-ba68-8c8a5b804cc8)

So the result in wikijourney will become title[edit]

![圖片](https://github.com/demegire/wiki-journey/assets/71842413/4778252d-da00-401a-b9d2-8ade708ec553)

I change the title fetch function, which will choose the first child of h1 instead of full hl. 